### PR TITLE
Mac OS X build compatibility

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -2,8 +2,10 @@ source build/envsetup.sh
 
 export LANG=en_US.UTF-8
 export _JAVA_OPTIONS=-XX:-UsePerfData
-export BUILD_NUMBER=$(cat out/build_number.txt 2>/dev/null || date --utc +%Y.%m.%d.%H)
+export BUILD_NUMBER=$(cat out/build_number.txt 2>/dev/null || date -u +%Y.%m.%d.%H)
 echo "BUILD_NUMBER=$BUILD_NUMBER"
 export DISPLAY_BUILD_NUMBER=true
-chrt -b -p 0 $$
+if [[ `uname` != 'Darwin' ]]; then
+    chrt -b -p 0 $$
+fi
 export PATH="$PWD/script/bin:$PATH"


### PR DESCRIPTION
Hello Daniel,

I understand that you are not going to support building on OS X. I was wondering if you would mind including these minor changes nevertheless to make it easier to tinker around with the sources for those who prefer Mac OS environments. 

This is my custom manifest to include the build system: https://gist.github.com/FeeJai/d4f8ba09ceb155dd6a9bba1904fca504