### PR TITLE
Fix signify_prehash.sh on Debian and Ubuntu

### DIFF
--- a/signify_prehash.sh
+++ b/signify_prehash.sh
@@ -10,4 +10,9 @@ key="$(realpath $1)"
 file=$(basename $2)
 
 cd "$(dirname $2)"
-sha256sum --tag "$file" | signify -S -s "$key" -e -m - -x "$file.sig"
+
+if [ "$(grep -E 'debian|ubuntu' /etc/os-release)" ]; then
+   sha256sum --tag "$file" | signify-openbsd -S -s "$key" -e -m - -x "$file.sig"
+else
+   sha256sum --tag "$file" | signify -S -s "$key" -e -m - -x "$file.sig"
+fi


### PR DESCRIPTION
Debian systems use signify-openbsd instead of signify