### PR TITLE
{encrypt,decrypt}_keys.sh: Prompt for passwords with read -r

### DIFF
--- a/decrypt_keys.sh
+++ b/decrypt_keys.sh
@@ -8,7 +8,7 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 cd $1
 
-[[ "${password+defined}" = defined ]] || read -p "Enter key passphrase (empty if none): " -s password
+[[ "${password+defined}" = defined ]] || read -r -p "Enter key passphrase (empty if none): " -s password
 echo
 
 tmp="$(mktemp -d /dev/shm/decrypt_keys.XXXXXXXXXX)"

--- a/encrypt_keys.sh
+++ b/encrypt_keys.sh
@@ -8,12 +8,12 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 cd $1
 
-read -p "Enter old key passphrase (empty if none): " -s password
+read -r -p "Enter old key passphrase (empty if none): " -s password
 echo
 
-read -p "Enter new key passphrase: " -s new_password
+read -r -p "Enter new key passphrase: " -s new_password
 echo
-read -p "Confirm new key passphrase: " -s confirm_new_password
+read -r -p "Confirm new key passphrase: " -s confirm_new_password
 echo
 
 if [[ $new_password != $confirm_new_password ]]; then


### PR DESCRIPTION
Without `-r`, bash interprets backslash-escaped characters inside the password by default.

This affects the `make_key` script too. I've submitted a PR for that here: https://gitlab.com/grapheneos/platform_development/-/merge_requests/1