### PR TITLE
remove duplicate Android.bp from unpacked otatools

### DIFF
--- a/generate-release.sh
+++ b/generate-release.sh
@@ -31,6 +31,9 @@ rm -rf $RELEASE_OUT
 mkdir -p $RELEASE_OUT
 unzip releases/$BUILD_NUMBER/$DEVICE-otatools.zip -d $RELEASE_OUT
 cd $RELEASE_OUT
+# remove duplicate Android.bp from unpacked otatools, otherwise they get
+# detected by soong, which breaks subsequent builds
+find -name Android.bp -delete
 
 # reproducible key path for otacerts.zip
 ln -s "$KEY_DIR" keys


### PR DESCRIPTION
This wasn't an issue previously, since otatools were unpacked inside $OUT_DIR, which is ignored by soong.