### PR TITLE
Fix non-literal password string comparison

### DIFF
--- a/encrypt_keys.sh
+++ b/encrypt_keys.sh
@@ -16,7 +16,7 @@ echo
 read -rp "Confirm new key passphrase: " -s confirm_new_password
 echo
 
-if [[ $new_password != $confirm_new_password ]]; then
+if [[ "$new_password" != "$confirm_new_password" ]]; then
     echo new password does not match
     exit 1
 fi

--- a/generate-releases.sh
+++ b/generate-releases.sh
@@ -6,7 +6,7 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -eq 1 ]] || user_error "expected 1 argument: BUILD_NUMBER"
 
-read -p "Enter key passphrase (empty if none): " -s password
+read -rp "Enter key passphrase (empty if none): " -s password
 echo
 export password
 

--- a/generate_deltas.sh
+++ b/generate_deltas.sh
@@ -6,7 +6,7 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -ge 2 ]] || user_error "expected 2 or more arguments (target and source versions)"
 
-read -p "Enter key passphrase (empty if none): " -s password
+read -rp "Enter key passphrase (empty if none): " -s password
 echo
 export password
 


### PR DESCRIPTION
When using `[[ $x != $y ]]`, the RHS argument is evaluated as a pattern instead of a string literal, unless it is quoted. This causes the check to incorrectly fail when using a randomly-generated password containing a backslash. For example, the password `test\%` never passes the check.

This commit also adds the `-r` argument to a couple password `read` calls that were missing it so that backslashes are not evaluated as escape characters.