### PR TITLE
Harden release scripts: fix metadata parsing, passphrase scoping, and path safety

### DIFF
--- a/decrypt-keys
+++ b/decrypt-keys
@@ -6,27 +6,26 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -ne 1 ]] && user_error "expected 1 argument (key directory)"
 
-cd $1
+cd "$1"
 
 [[ "${password+defined}" = defined ]] || read -rp "Enter key passphrase (empty if none): " -s password
 echo
+export -n password
 
 tmp="$(mktemp -d /dev/shm/decrypt-keys.XXXXXXXXXX)"
 trap "rm -rf \"$tmp\"" EXIT
 
-export password
-
-for key in ${signing_keys[@]}; do
+for key in "${signing_keys[@]}"; do
     if [[ -n $password ]]; then
-        openssl pkcs8 -inform DER -in $key.pk8 -passin env:password | openssl pkcs8 -topk8 -outform DER -out "$tmp/$key.pk8" -nocrypt
+        env "password=$password" openssl pkcs8 -inform DER -in "$key.pk8" -passin env:password | openssl pkcs8 -topk8 -outform DER -out "$tmp/$key.pk8" -nocrypt
     else
-        openssl pkcs8 -topk8 -inform DER -in $key.pk8 -outform DER -out "$tmp/$key.pk8" -nocrypt
+        openssl pkcs8 -topk8 -inform DER -in "$key.pk8" -outform DER -out "$tmp/$key.pk8" -nocrypt
     fi
 done
 
 if [[ -f avb.pem ]]; then
     if [[ -n $password ]]; then
-        openssl pkcs8 -topk8 -in avb.pem -passin env:password -out "$tmp/avb.pem" -nocrypt
+        env "password=$password" openssl pkcs8 -topk8 -in avb.pem -passin env:password -out "$tmp/avb.pem" -nocrypt
     else
         openssl pkcs8 -topk8 -in avb.pem -out "$tmp/avb.pem" -nocrypt
     fi

--- a/encrypt-keys
+++ b/encrypt-keys
@@ -6,7 +6,7 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -ne 1 ]] && user_error "expected 1 argument (key directory)"
 
-cd $1
+cd "$1"
 
 read -rp "Enter old key passphrase (empty if none): " -s password
 echo
@@ -20,26 +20,24 @@ if [[ "$new_password" != "$confirm_new_password" ]]; then
     echo new password does not match
     exit 1
 fi
+export -n password new_password confirm_new_password
 
 tmp="$(mktemp -d /dev/shm/encrypt-keys.XXXXXXXXXX)"
 trap "rm -rf \"$tmp\"" EXIT
 
-export password
-export new_password
-
-for key in ${signing_keys[@]}; do
+for key in "${signing_keys[@]}"; do
     if [[ -n $password ]]; then
-        openssl pkcs8 -inform DER -in $key.pk8 -passin env:password | openssl pkcs8 -topk8 -outform DER -out "$tmp/$key.pk8" -passout env:new_password -scrypt
+        env "password=$password" openssl pkcs8 -inform DER -in "$key.pk8" -passin env:password | env "new_password=$new_password" openssl pkcs8 -topk8 -outform DER -out "$tmp/$key.pk8" -passout env:new_password -scrypt
     else
-        openssl pkcs8 -topk8 -inform DER -in $key.pk8 -outform DER -out "$tmp/$key.pk8" -passout env:new_password -scrypt
+        env "new_password=$new_password" openssl pkcs8 -topk8 -inform DER -in "$key.pk8" -outform DER -out "$tmp/$key.pk8" -passout env:new_password -scrypt
     fi
 done
 
 if [[ -f avb.pem ]]; then
     if [[ -n $password ]]; then
-        openssl pkcs8 -topk8 -in avb.pem -passin env:password -out "$tmp/avb.pem" -passout env:new_password -scrypt
+        env "password=$password" "new_password=$new_password" openssl pkcs8 -topk8 -in avb.pem -passin env:password -out "$tmp/avb.pem" -passout env:new_password -scrypt
     else
-        openssl pkcs8 -topk8 -in avb.pem -out "$tmp/avb.pem" -passout env:new_password -scrypt
+        env "new_password=$new_password" openssl pkcs8 -topk8 -in avb.pem -out "$tmp/avb.pem" -passout env:new_password -scrypt
     fi
 fi
 

--- a/generate-delta.sh
+++ b/generate-delta.sh
@@ -6,6 +6,10 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -eq 3 ]] || user_error "expected 3 arguments (device, source and target version)"
 
+if [[ "${password+defined}" = defined ]]; then
+    export -n password
+fi
+
 chrt -b -p 0 $$
 
 PERSISTENT_KEY_DIR=keys/$1
@@ -17,7 +21,12 @@ NEW=$3
 KEY_DIR=$(mktemp -d /dev/shm/generate-delta.XXXXXXXXXX)
 trap "rm -rf \"$KEY_DIR\"" EXIT
 cp "$PERSISTENT_KEY_DIR"/* "$KEY_DIR"
-script/decrypt-keys "$KEY_DIR"
+if [[ "${password+defined}" = defined ]]; then
+    env "password=$password" script/decrypt-keys "$KEY_DIR"
+    unset password
+else
+    script/decrypt-keys "$KEY_DIR"
+fi
 
 export PATH="$PWD/prebuilts/build-tools/linux-x86/bin:$PATH"
 export PATH="$PWD/prebuilts/build-tools/path/linux-x86:$PATH"

--- a/generate-deltas.sh
+++ b/generate-deltas.sh
@@ -8,7 +8,6 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 read -rp "Enter key passphrase (empty if none): " -s password
 echo
-export password
 
 chrt -b -p 0 $$
 
@@ -17,4 +16,4 @@ shift
 
 export TMPDIR="${OUT:-$PWD/delta-generation}"
 
-parallel -j4 -q script/generate-delta.sh ::: stallion rango mustang blazer frankel tegu comet komodo caiman tokay akita husky shiba felix tangorpro lynx cheetah panther bluejay raven oriole ::: $@ ::: $SOURCE
+env "password=$password" parallel -j4 -q script/generate-delta.sh ::: stallion rango mustang blazer frankel tegu comet komodo caiman tokay akita husky shiba felix tangorpro lynx cheetah panther bluejay raven oriole ::: $@ ::: $SOURCE

--- a/generate-keys
+++ b/generate-keys
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+set -o errexit -o nounset -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 devices=()
 
-for device in ${devices[@]}; do
-    mkdir -p keys/$device
-    cd keys/$device
+for device in "${devices[@]}"; do
+    mkdir -p "keys/$device"
+    cd "keys/$device"
     CN=GrapheneOS
-    for key in ${signing_keys[@]}; do
-        ../../development/tools/make_key $key "/CN=$CN/"
+    for key in "${signing_keys[@]}"; do
+        ../../development/tools/make_key "$key" "/CN=$CN/"
     done
     openssl genrsa 4096 | openssl pkcs8 -topk8 -scrypt -out avb.pem
     ../../external/avb/avbtool.py extract_public_key --key avb.pem --output avb_pkmd.bin

--- a/generate-metadata
+++ b/generate-metadata
@@ -9,10 +9,25 @@ parser.add_argument("zip")
 
 zip_path = parser.parse_args().zip
 
+
+def parse_metadata(metadata):
+    data = {}
+    for raw_line in metadata:
+        line = raw_line.decode().rstrip("\n")
+        key, separator, value = line.partition("=")
+        if not separator:
+            raise ValueError(f"malformed metadata line: {line!r}")
+        data[key] = value
+    return data
+
+
 with ZipFile(zip_path) as f:
     with f.open("META-INF/com/android/metadata") as metadata:
-        data = dict(line[:-1].decode().split("=") for line in metadata)
+        data = parse_metadata(metadata)
+        missing = {"post-build-incremental", "post-timestamp", "pre-device"} - data.keys()
+        if missing:
+            raise ValueError("metadata is missing required fields: " + ", ".join(sorted(missing)))
+        incremental = data["post-build-incremental"]
         for channel in ("beta", "stable", "alpha", "testing"):
             with open(path.join(path.dirname(zip_path), data["pre-device"] + "-" + channel), "w") as output:
-                incremental = data["post-build"].split("/")[4].split(":")[0]
                 print(incremental, data["post-timestamp"], data["pre-device"], channel, file=output)

--- a/generate-release.sh
+++ b/generate-release.sh
@@ -6,6 +6,10 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 [[ $# -eq 2 ]] || user_error "expected two arguments: DEVICE BUILD_NUMBER"
 
+if [[ "${password+defined}" = defined ]]; then
+    export -n password
+fi
+
 chrt -b -p 0 $$
 
 DEVICE=$1
@@ -18,7 +22,12 @@ RELEASE_OUT=releases/$BUILD_NUMBER/release-$DEVICE-$BUILD_NUMBER
 KEY_DIR=$(mktemp -d /dev/shm/generate-release.XXXXXXXXXX)
 trap "rm -rf \"$KEY_DIR\" && rm -f \"$PWD/$RELEASE_OUT/keys\"" EXIT
 cp "$PERSISTENT_KEY_DIR"/* "$KEY_DIR"
-script/decrypt-keys "$KEY_DIR"
+if [[ "${password+defined}" = defined ]]; then
+    env "password=$password" script/decrypt-keys "$KEY_DIR"
+    unset password
+else
+    script/decrypt-keys "$KEY_DIR"
+fi
 
 OLD_PATH="$PATH"
 export PATH="$PWD/prebuilts/build-tools/linux-x86/bin:$PATH"

--- a/generate-release.sh
+++ b/generate-release.sh
@@ -36,10 +36,10 @@ export PATH="$PWD/prebuilts/build-tools/path/linux-x86:$PATH"
 TARGET_FILES=$DEVICE-target_files.zip
 TARGET_FILES_INPUT=$PWD/releases/$BUILD_NUMBER/$TARGET_FILES
 
-rm -rf $RELEASE_OUT
-mkdir -p $RELEASE_OUT
-unzip releases/$BUILD_NUMBER/$DEVICE-otatools.zip -d $RELEASE_OUT
-cd $RELEASE_OUT
+rm -rf "$RELEASE_OUT"
+mkdir -p "$RELEASE_OUT"
+unzip "releases/$BUILD_NUMBER/$DEVICE-otatools.zip" -d "$RELEASE_OUT"
+cd "$RELEASE_OUT"
 # make soong ignore Android.bp from unpacked otatools to avoid breaking subsequent builds
 touch .find-ignore
 
@@ -60,7 +60,7 @@ get_radio_image() {
     grep "require version-$1" OTA/android-info.txt | cut -d '=' -f 2 | tr '[:upper:]' '[:lower:]'
 }
 
-unzip $TARGET_FILES_INPUT OTA/android-info.txt
+unzip "$TARGET_FILES_INPUT" OTA/android-info.txt
 
 if [[ $DEVICE == @(rango|mustang|blazer|frankel) ]]; then
     BOOTLOADER=$(get_radio_image bootloader)

--- a/generate-releases.sh
+++ b/generate-releases.sh
@@ -8,10 +8,9 @@ source "$(dirname ${BASH_SOURCE[0]})/common.sh"
 
 read -rp "Enter key passphrase (empty if none): " -s password
 echo
-export password
 
 chrt -b -p 0 $$
 
 export TMPDIR="${OUT:-$PWD/delta-generation}"
 
-parallel -j4 -q script/generate-release.sh ::: stallion rango mustang blazer frankel tegu comet komodo caiman tokay akita husky shiba felix tangorpro lynx cheetah panther bluejay raven oriole ::: $1
+env "password=$password" parallel -j4 -q script/generate-release.sh ::: stallion rango mustang blazer frankel tegu comet komodo caiman tokay akita husky shiba felix tangorpro lynx cheetah panther bluejay raven oriole ::: $1


### PR DESCRIPTION
- Fix `generate-metadata` OTA metadata parsing
  - Replace unbounded `split("=")` with `partition("=")`, which handles build fingerprints and other values that contain `=`.
  - Use `post-build-incremental` directly instead of indexing into `post-build`; add required-field validation for `post-build-incremental`, `post-timestamp`, and `pre-device`.

- Add strict shell failure handling to `generate-keys`
  - Enables `errexit`, `nounset`, and `pipefail`.
  - Quotes path and array expansions in the key generation loop.

- Avoid exporting key passphrases broadly
  - `decrypt-keys` and `encrypt-keys` scope passphrase variables to the specific `openssl` invocations that need them via `env "password=..." openssl ...`; also fix `cd $1` → `cd "$1"` and array/filename quoting in the key loops.
  - `generate-release.sh` and `generate-delta.sh` strip inherited passphrase export state, pass it only to `decrypt-keys`, then unset it.
  - `generate-releases.sh` and `generate-deltas.sh` no longer export the passphrase for their whole shell process.

- Quote release output paths in `generate-release.sh`
  - Quotes `$RELEASE_OUT` in `rm -rf`, `mkdir`, `unzip -d`, and `cd`.
  - Quotes `$TARGET_FILES_INPUT` when extracting `OTA/android-info.txt`.